### PR TITLE
删除默认的 successReturnToOrRedirect  重定向，默认的重定向会让egg-passport 作为中间件使用时产生副作用

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,62 @@
+import {
+    Application,
+    Context,
+    Request,
+} from 'egg';
+import {
+    Middleware,
+} from "koa";
+import * as passport from "passport";
+
+declare module 'egg' {
+    interface Application {
+        passport: EggPassport.passport;
+    }
+
+    interface EggApplication {
+        passport: EggPassport.passport;
+    }
+
+    interface User {
+        id: number | string;
+        provider: string;
+    }
+
+    interface Context {
+        user: any;
+        login(user: any, options?: any): Promise<void>;
+        logIn: Context["login"];
+
+        logout(): void;
+        logOut: Context["logout"];
+
+        isAuthenticated(): boolean;
+        isUnauthenticated(): boolean;
+    }
+}
+
+declare namespace EggPassport {
+    class passport {
+        init(): void;
+
+        use(strategy: passport.Strategy): this;
+        use(name: string, strategy: passport.Strategy): this;
+        unuse(name: string): this;
+
+        framework(fw: passport.Framework): this;
+
+        session(): Middleware;
+
+        authenticate(strategy: string | string[], options: passport.AuthenticateOptions | object): Middleware;
+
+        serializeUser: passport.Authenticator["serializeUser"];
+        deserializeUser: passport.Authenticator["deserializeUser"];
+
+        doVerify(req: Request, user: {}, done: any): void;
+        verify(handler: (ctx: Context, user: {}) => {} | undefined): void;
+    }
+}
+
+declare const eggPassport: EggPassport.passport;
+
+export = eggPassport;

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -37,11 +37,6 @@ class EggPassport extends Passport {
    * @api public
    */
   authenticate(strategy, options = {}) {
-    // try to use successReturnToOrRedirect first
-    if (!options.hasOwnProperty('successRedirect') && !options.hasOwnProperty('successReturnToOrRedirect')) {
-      // app use set `ctx.session.returnTo = ctx.path` before auth redirect
-      options.successReturnToOrRedirect = '/';
-    }
     if (!options.hasOwnProperty('failWithError')) {
       options.failWithError = true;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [] documentation is changed or added
- [] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
只是删除了默认的重定向，我认为人们如果真的需要跳转会自己设定路由的。现在的默认配置在文档中也没有体现，所以产生了令人疑惑的默认重定向效果

与此相关的 ISSUE:
- https://github.com/eggjs/egg/issues/3159
- https://github.com/eggjs/egg/issues/3257

##### Description of change
<!-- Provide a description of the change below this comment. -->
