### PR TITLE
feat: allow pass full qualified callback url to passport and make sur…

### DIFF
--- a/lib/passport.js
+++ b/lib/passport.js
@@ -4,6 +4,7 @@ const debug = require('debug')('egg-passport:passport');
 const Passport = require('passport').Passport;
 const SessionStrategy = require('passport').strategies.SessionStrategy;
 const framework = require('./framework');
+const url = require('url');
 
 class EggPassport extends Passport {
   constructor(app) {
@@ -56,8 +57,8 @@ class EggPassport extends Passport {
     options.loginURL = options.loginURL || `/passport/${strategy}`;
     options.callbackURL = options.callbackURL || `/passport/${strategy}/callback`;
     const auth = this.authenticate(strategy, options);
-    this.app.get(options.loginURL, auth);
-    this.app.get(options.callbackURL, auth);
+    this.app.get(url.parse(options.loginURL).pathname, auth);
+    this.app.get(url.parse(options.callbackURL).pathname, auth);
   }
 
   doVerify(req, user, done) {

--- a/test/fixtures/full-url-test/app.js
+++ b/test/fixtures/full-url-test/app.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = app => {
+  app.passport.verify(function* (ctx, user) {
+    if (user.provider === 'localapikey') {
+      if (user.apikey === 'eggapp') {
+        user.name = 'eggapp';
+        user.displayName = 'my name is egg';
+        user.photo = 'https://zos.alipayobjects.com/rmsportal/JFKAMfmPehWfhBPdCjrw.svg';
+        user.profile = {
+          _json: user,
+        };
+      } else {
+        return null;
+      }
+    }
+
+    return user;
+  });
+
+  app.passport.serializeUser(function* (ctx, user) {
+    user.currentUrl = ctx.url;
+    return user;
+  });
+
+  app.passport.deserializeUser(function* (ctx, user) {
+    user.lastUrl = user.currentUrl;
+    user.currentUrl = ctx.url;
+    return user;
+  });
+};

--- a/test/fixtures/full-url-test/app/controller/home.js
+++ b/test/fixtures/full-url-test/app/controller/home.js
@@ -1,0 +1,27 @@
+'use strict';
+
+exports.index = function* () {
+  if (this.isAuthenticated()) {
+    this.body = `<div>
+      <h2>${this.path}</h2>
+      <hr>
+      Authenticated user: <img src="${this.user.photo}"> ${this.user.displayName} / ${this.user.id} | <a href="/logout">Logout</a>
+      <pre><code>${JSON.stringify(this.user, null, 2)}</code></pre>
+      <hr>
+      <a href="/">Home</a> | <a href="/user">User</a>
+    </div>`;
+  } else {
+    this.session.returnTo = this.path;
+    this.body = `
+      <div>
+        <h2>${this.path}</h2>
+        <hr>
+        Login with
+        <a href="/passport/weibo">Weibo</a> | <a href="/passport/github">Github</a> |
+        <a href="/passport/bitbucket">Bitbucket</a> | <a href="/passport/twitter">Twitter</a>
+        <hr>
+        <a href="/">Home</a> | <a href="/user">User</a>
+      </div>
+    `;
+  }
+};

--- a/test/fixtures/full-url-test/app/controller/user.js
+++ b/test/fixtures/full-url-test/app/controller/user.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.logout = function* () {
+  this.logout();
+  this.redirect(this.get('referer') || '/');
+};

--- a/test/fixtures/full-url-test/app/plugin/passport-localapikey/app.js
+++ b/test/fixtures/full-url-test/app/plugin/passport-localapikey/app.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const debug = require('debug')('egg-passport-localapikey');
+const Strategy = require('passport-localapikey').Strategy;
+
+module.exports = app => {
+  const config = app.config.passportLocalapikey;
+  // must set passReqToCallback to true
+  config.passReqToCallback = true;
+
+  // register localapikey strategy into `app.passport`
+  // must require `req` params
+  app.passport.use('localapikey', new Strategy(config, (req, apikey, done) => {
+    // format user
+    const user = {
+      provider: 'localapikey',
+      id: apikey,
+      apikey,
+    };
+    debug('%s %s get user: %j', req.method, req.url, user);
+    // let passport do verify and call verify hook
+    app.passport.doVerify(req, user, done);
+  }));
+};

--- a/test/fixtures/full-url-test/app/plugin/passport-localapikey/config/config.default.js
+++ b/test/fixtures/full-url-test/app/plugin/passport-localapikey/config/config.default.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.passportLocalapikey = {};

--- a/test/fixtures/full-url-test/app/plugin/passport-localapikey/package.json
+++ b/test/fixtures/full-url-test/app/plugin/passport-localapikey/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "egg-passport-localapikey",
+  "eggPlugin": {
+    "name": "passportLocalapikey",
+    "dependencies": [
+      "passport"
+    ]
+  }
+}

--- a/test/fixtures/full-url-test/app/router.js
+++ b/test/fixtures/full-url-test/app/router.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = app => {
+  app.get('/', 'home.index');
+  app.get('/user', 'home.index');
+
+  app.passport.mount('github', {
+    callbackURL: 'https://example.com/passport/github/callback',
+  });
+};

--- a/test/fixtures/full-url-test/app/service/user.js
+++ b/test/fixtures/full-url-test/app/service/user.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = app => {
+  return class UserService extends app.Service {
+    * find() {
+      return this.ctx.user;
+    }
+  };
+};

--- a/test/fixtures/full-url-test/config/config.default.js
+++ b/test/fixtures/full-url-test/config/config.default.js
@@ -1,0 +1,18 @@
+'use strict';
+
+exports.keys = 'foo';
+
+exports.passportWeibo = {
+  key: process.env.EGG_PASSPORT_WEIBO_CLIENT_ID,
+  secret: process.env.EGG_PASSPORT_WEIBO_CLIENT_SECRET,
+};
+
+exports.passportTwitter = {
+  key: process.env.EGG_PASSPORT_TWITTER_CONSUMER_KEY,
+  secret: process.env.EGG_PASSPORT_TWITTER_CONSUMER_SECRET,
+};
+
+exports.passportGithub = {
+  key: 'wrong-client-id',
+  secret: 'wrong-client-secret',
+};

--- a/test/fixtures/full-url-test/config/plugin.js
+++ b/test/fixtures/full-url-test/config/plugin.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const path = require('path');
+
+exports.passportWeibo = {
+  enable: true,
+  package: 'egg-passport-weibo',
+};
+
+exports.passportTwitter = {
+  enable: true,
+  package: 'egg-passport-twitter',
+};
+
+exports.passportGithub = {
+  enable: true,
+  package: 'egg-passport-github',
+};
+
+exports.passportLocalapikey = {
+  enable: true,
+  path: path.join(__dirname, '../app/plugin/passport-localapikey'),
+};

--- a/test/fixtures/full-url-test/package.json
+++ b/test/fixtures/full-url-test/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "plugin-test"
+}

--- a/test/full-url.test.js
+++ b/test/full-url.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const mm = require('egg-mock');
+
+describe('test/full-url.test.js', () => {
+  let app;
+  before(() => {
+    app = mm.app({
+      baseDir: 'full-url-test',
+    });
+    return app.ready();
+  });
+
+  after(() => app.close());
+
+  afterEach(mm.restore);
+
+  it('should redirect to github oauth url', () => {
+    return app.httpRequest()
+      .get('/passport/github')
+      .expect(/Found/)
+      .expect('Location', /https:\/\/github.com\/login\/oauth\/authorize\?response_type=code&redirect_uri=https/)
+      .expect(302);
+  });
+
+  it('should GET callback also redirect to github oauth url', () => {
+    return app.httpRequest()
+      .get('/passport/github/callback')
+      .expect(/Found/)
+      .expect('Location', /https:\/\/github.com\/login\/oauth\/authorize\?response_type=code&redirect_uri=https/)
+      .expect(302);
+  });
+});


### PR DESCRIPTION
…e the authentication generate the correct redirect_uri.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
在对接 github oauth 时发现 redirect_uri 总是不匹配的问题，最终找到的原因是，我的站点部署到了 https 下，而该插件在生成 authentication 时，redirect_uri 总是 http 的。

于是尝试在 mount 时，把 https://example.com/passport/github/callback 这样的完整 url 传进去，但是仍然会出问题。

所以改造了 passport 的 mount 方法，使其接受完整的 url，这样，最终生成的 redirect_uri 就是对的了（https）。

附上了测试代码验证通过。